### PR TITLE
Add uuidgen availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 brew install atomicparsley
 ```
 
+确保系统中提供 `uuidgen` 命令（在大多数 Linux 发行版中属于 util-linux 包，macOS 默认自带）。
 配置
 
 ```shell

--- a/mp4-obfuscator.sh
+++ b/mp4-obfuscator.sh
@@ -6,6 +6,12 @@ if ! command -v AtomicParsley &>/dev/null; then
     exit 1
 fi
 
+# 检查是否安装了 uuidgen
+if ! command -v uuidgen &>/dev/null; then
+    echo "❌ uuidgen 未安装，请先安装后再运行。"
+    exit 1
+fi
+
 # 判断当前目录下是否有 mp4 文件
 mp4_count=$(ls *.mp4 2>/dev/null | wc -l)
 if [ "$mp4_count" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- ensure `uuidgen` command is available before starting the obfuscation script
- mention `uuidgen` in install instructions

## Testing
- `git log -1 --stat`
